### PR TITLE
skip all treesitters tests if \!test_all

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgmatch
 Title:  Find R Packages Matching Either Descriptions or Other R Packages
-Version: 0.5.0.043
+Version: 0.5.0.044
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgmatch",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgmatch/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.5.0.043",
+  "version": "0.5.0.044",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/tests/testthat/test-treesitter.R
+++ b/tests/testthat/test-treesitter.R
@@ -1,6 +1,8 @@
 test_all <- (identical (Sys.getenv ("MPADGE_LOCAL"), "true") ||
     identical (Sys.getenv ("GITHUB_JOB"), "test-coverage"))
 
+skip_if (!test_all)
+
 test_that ("tree-sitter", {
 
     withr::local_envvar (list ("PKGMATCH_TESTS" = "true"))
@@ -22,7 +24,6 @@ test_that ("tree-sitter", {
 })
 
 
-skip_if (!test_all)
 test_that ("tree-sitter installed package", {
     pkg <- "rappdirs"
     tags <- pkgmatch_treesitter_fn_tags (pkg)


### PR DESCRIPTION
B/c on pkgcheck it fails to find the namespace file