### PR TITLE
separate data-raw/start.sh file for Docker build #221

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgmatch
 Title: Find R Packages Matching Either Descriptions or Other R Packages
-Version: 0.5.0.103
+Version: 0.5.0.104
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,12 @@ RUN apt-get update && apt-get install -y curl
 
 RUN --mount=type=secret,id=GITHUB_PAT,env=GITHUB_PAT installGithub.r \
     ropensci-review-tools/pkgmatch
-# RUN Rscript -e 'pkgmatch::pkgmatch_update_cache()'
 
 RUN curl -fsSL https://ollama.com/install.sh | sh
 
-RUN nohup bash -c "ollama serve &" \
-    && sleep 5 \
-    && ollama pull jina/jina-embeddings-v2-base-en \
-    && ollama pull unclemusclez/jina-embeddings-v2-base-code
+COPY data-raw/start.sh /start.sh
+RUN cmhod +x /start.sh
 
 EXPOSE 11434
 
-ENTRYPOINT ["Rscript", "-e", "pkgmatch::pkgmatch_update_data()"]
+ENTRYPOINT ["/start.sh"]

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgmatch",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgmatch/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.5.0.103",
+  "version": "0.5.0.104",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/data-raw/start.sh
+++ b/data-raw/start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+nohup ollama serve &
+sleep 5
+
+ollama pull jina/jina-embeddings-v2-base-en
+ollama pull unclemusclez/jina-embeddings-v2-base-code
+
+exec Rscript -e "pkgmatch::pkgmatch_update_data()"


### PR DESCRIPTION
The main dockerfile now just installs ollama but nothing else; the script is the entrypoint which downloads models and calls the update function