### PR TITLE
add 'mpadge/pkgcheck' tags to docker build workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -44,4 +44,5 @@ jobs:
           secrets: |
               "GITHUB_PAT=${{ secrets.GITHUB_TOKEN }}"
           tags: |
+            mpadge/pkgcheck:latest
             ghcr.io/ropensci-review-tools/pkgmatch:latest

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgmatch
 Title: Find R Packages Matching Either Descriptions or Other R Packages
-Version: 0.5.0.106
+Version: 0.5.0.107
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgmatch",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgmatch/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.5.0.106",
+  "version": "0.5.0.107",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
can't pull container as is because 'unauthorized'. This seems to be the only diff to pkgcheck container, which otherwise works find.