### PR TITLE
docker build with explicit suggests pkgs in dockerfile

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgmatch
 Title: Find R Packages Matching Either Descriptions or Other R Packages
-Version: 0.5.0.110
+Version: 0.5.0.111
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,14 @@ RUN install2.r \
     xml2 \
     httr2
 
+# Plus all 'Suggests' packages needed for update fn:
+RUN install2.r \
+    gert \
+    hms \
+    jsonlite \
+    rappdirs \
+    withr
+
 RUN --mount=type=secret,id=GITHUB_PAT,env=GITHUB_PAT installGithub.r \
     ropensci-review-tools/pkgmatch
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgmatch",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgmatch/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.5.0.110",
+  "version": "0.5.0.111",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
Because these are otherwise not installed by installGithub.r r2u fn