### PR TITLE
catch error in deleting cran tarball path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgmatch
 Title: Find R Packages Matching Either Descriptions or Other R Packages
-Version: 0.5.2.110
+Version: 0.5.2.111
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/R/data-update-cran.R
+++ b/R/data-update-cran.R
@@ -53,7 +53,10 @@ pkgmatch_update_cran <- function (flist, local_mirror_path = NULL, minchar = 3L)
             ret <- extract_tarball (tarball_path, exdir)
         }
         if (is.null (local_mirror_path)) {
-            fs::file_delete (tarball_path)
+            tryCatch (
+                fs::file_delete (tarball_path),
+                error = function (e) NULL
+            )
         }
         return (ret)
     })

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgmatch",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgmatch/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.5.2.110",
+  "version": "0.5.2.111",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
One pkg failed to extract, and so had a 'path' of 'NULL'